### PR TITLE
Only run CI using Java 8 as that is all GlassFish 6.0.0-M1 supports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,8 @@ jobs:
       - run: ./mvnw verify
       - store_test_results:
           path: target/surefire-reports
+      - store_test_results:
+          path: glassfish-managed-6/target/glassfish6/glassfish/domains/domain1/logs/server.log
       - save_cache:
           paths:
             - ~/.m2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,10 @@ jobs:
           key: circleci-arquillian-container-glassfish-6-{{ checksum "pom.xml" }}
       - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
       - run: ./mvnw verify
-      - run: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target
+      - run:
+          name: Target glassfish-managed-6/target
+          command: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target
+          when: always
       - store_artifacts:
           path: glassfish-managed-6.tar.gz
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,7 @@ jobs:
           key: circleci-arquillian-container-glassfish-6-{{ checksum "pom.xml" }}
       - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
       - run: ./mvnw verify
-      - run:
-        name: Compress glassfish-managed-6 target
-        command: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target
+      - run: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target
       - store_artifacts:
         path: glassfish-managed-6.tar.gz
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - restore_cache:
           key: circleci-arquillian-container-glassfish-6-{{ checksum "pom.xml" }}
       - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
-      - run: ./mvnw verify
+      - run: ./mvnw -X verify
       - run:
           name: Target glassfish-managed-6/target
           command: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - run: ./mvnw verify
       - run: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target
       - store_artifacts:
-        path: glassfish-managed-6.tar.gz
+          path: glassfish-managed-6.tar.gz
       - store_artifacts:
           path: glassfish-managed-6/target/glassfish6/glassfish/domains/domain1/logs/server.log
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,4 +27,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              jdk-version: ["8", "9"]
+              jdk-version: ["8"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,10 +13,15 @@ jobs:
           key: circleci-arquillian-container-glassfish-6-{{ checksum "pom.xml" }}
       - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
       - run: ./mvnw verify
+      - run:
+        name: Compress glassfish-managed-6 target
+        command: tar -czvf glassfish-managed-6.tar.gz glassfish-managed-6/target
+      - store_artifacts:
+        path: glassfish-managed-6.tar.gz
+      - store_artifacts:
+          path: glassfish-managed-6/target/glassfish6/glassfish/domains/domain1/logs/server.log
       - store_test_results:
           path: target/surefire-reports
-      - store_test_results:
-          path: glassfish-managed-6/target/glassfish6/glassfish/domains/domain1/logs/server.log
       - save_cache:
           paths:
             - ~/.m2

--- a/glassfish-managed-6/src/main/java/org/jboss/arquillian/container/glassfish/managed_6/GlassFishServerControl.java
+++ b/glassfish-managed-6/src/main/java/org/jboss/arquillian/container/glassfish/managed_6/GlassFishServerControl.java
@@ -173,6 +173,9 @@ class GlassFishServerControl {
         if (result != 0) {
             throw new LifecycleException("Unable to execute " + cmd.toString());
         }
+        if (config.isOutputToConsole()) {
+            System.out.println(description + " process started");
+        }
     }
 
     private List<String> buildCommand(String command, List<String> args) {

--- a/glassfish-managed-6/src/test/resources/arquillian.xml
+++ b/glassfish-managed-6/src/test/resources/arquillian.xml
@@ -18,7 +18,7 @@
       <property name="allowConnectingToRunningServer">false</property>
       <property name="outputToConsole">true</property>
       <!-- true enables verbose logging of the jaxrs requests -->
-      <property name="debugRequests">true</property>
+      <property name="debugRequests">false</property>
     </configuration>
   </container>
 


### PR DESCRIPTION
Signed-off-by: Scott M Stark <starksm64@gmail.com>

Should fix the current CI test failures